### PR TITLE
To Grid update function added Node cluster reset

### DIFF
--- a/main.py
+++ b/main.py
@@ -208,7 +208,10 @@ class Grid(Node):
         """Процедура обновления сетки"""
         for link in self.links_list:
             link.update()
-        self.clusters_list = []
+        for cluster in self.clusters_list:
+            for node in cluster.nodes_list:
+                node.cluster = None
+        self.clusters_list.clear()
         self.find_clusters()
 
 


### PR DESCRIPTION
![изображение](https://user-images.githubusercontent.com/71838879/222112478-818b66a1-9d50-4543-ad7c-ba51c8ca6f6a.png)

![изображение](https://user-images.githubusercontent.com/71838879/222112531-f8423d2d-e592-4727-83cf-85c3f1234f7f.png)


Во время обновления сетки у всех Node параметр cluster равен не None а кластеру, которому она принадлежала до обновления, Из-за этого функция find_clusters дает не тот результат который мы ожидаем. 
Поэтому при обновлении сетки стоит сбрасывать ссылку на кластер каждой ноды.

Список кластеров можно очищать функцией clear, а не создавая новый список.
Не думаю, что это существенно, но мне так больше нравится.